### PR TITLE
Improve n-gram handling and expand tests

### DIFF
--- a/src/__tests__/sentiment.test.ts
+++ b/src/__tests__/sentiment.test.ts
@@ -39,6 +39,9 @@ describe("Sentiment Analysis", () => {
     const result = analyzer.analyze("");
     expect(result.score).toBe(0);
     expect(result.tokens).toHaveLength(0);
+    expect(result.words).toHaveLength(0);
+    expect(result.positive).toHaveLength(0);
+    expect(result.negative).toHaveLength(0);
   });
 
   test("handles unknown language gracefully", () => {

--- a/src/__tests__/tokenizer.test.ts
+++ b/src/__tests__/tokenizer.test.ts
@@ -184,4 +184,9 @@ describe("Tokenizer - ngrams", () => {
     const resultFourgrams = Tokenizer.getNGrams(input2, 4, true);
     expect(resultFourgrams).toEqual(expectedFourgrams);
   });
+
+  it("should return an empty array when n is zero or negative", () => {
+    expect(Tokenizer.getNGrams("abc", 0)).toEqual([]);
+    expect(Tokenizer.getNGrams("abc", -2)).toEqual([]);
+  });
 });

--- a/src/sentiment.ts
+++ b/src/sentiment.ts
@@ -26,12 +26,24 @@ export class BaseSentiment implements ISentiment {
         break;
     }
 
+    if (!text) {
+      return {
+        score: 0,
+        comparative: 0,
+        tokens: [],
+        words: [],
+        positive: [],
+        negative: [],
+      };
+    }
+
     // Tokenize the text using the language‑specific tokenizer
     const tokenizer = new langModule.Tokenizer();
     const tokens = tokenizer.tokenize(text);
-    
-    // Process tokens with stemmer
-    const processedTokens = tokens.map(token => new langModule.Stemmer().stem(token));
+
+    // Process tokens with a single stemmer instance
+    const stemmer = new langModule.Stemmer();
+    const processedTokens = tokens.map((token) => stemmer.stem(token));
 
     // Simplified result without sentiment analysis
     return {

--- a/src/tokenizer.ts
+++ b/src/tokenizer.ts
@@ -147,8 +147,8 @@ export class Tokenizer implements ITokenizer {
     n = 3,
     joinTokens = true
   ): (string[] | string)[] {
-    // Return an empty array for falsy or empty input.
-    if (!srcValue) return [];
+    // Return an empty array for falsy input or non-positive n.
+    if (!srcValue || n <= 0) return [];
 
     // Remove diacritics and convert the input to a string.
     const cleaned = Diacritics.remove(String(srcValue));
@@ -219,13 +219,14 @@ export class Tokenizer implements ITokenizer {
    */
   private filterStopWords(tokens: string[], opts: TokenizerOptions): string[] {
     const languageStopWords: ReadonlySet<string> = this.getStopWords(opts);
-    const customStopWords: ReadonlySet<string> = new Set(
-      opts.customStopWords ?? []
-    );
-    const allStopWords: ReadonlySet<string> = new Set([
-      ...languageStopWords,
-      ...customStopWords,
-    ]);
-    return tokens.filter((token: string): boolean => !allStopWords.has(token));
+    const customStopWordsSet =
+      opts.customStopWords && opts.customStopWords.length > 0
+        ? new Set(opts.customStopWords)
+        : undefined;
+
+    return tokens.filter((token: string): boolean => {
+      if (languageStopWords.has(token)) return false;
+      return customStopWordsSet ? !customStopWordsSet.has(token) : true;
+    });
   }
 }


### PR DESCRIPTION
## Summary
- guard against non-positive values in `Tokenizer.getNGrams`
- extend empty text sentiment test
- add regression tests for `getNGrams` edge cases

## Testing
- `npm test`